### PR TITLE
Quote string containing colon

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'main'
   branch-checkout-args:
-    description: Arguments to pass to `git checkout`: `git checkout ${checkout-args} "${branch}"`
+    description: 'Arguments to pass to `git checkout`: `git checkout ${checkout-args} "${branch}"`'
     required: false
     default: ''
   dir_docs:


### PR DESCRIPTION
The description string contains a colon, causing the YAML parser to be recognized is as a mapping:
"Mapping values are not allowed in this context"

Quotes resolve the error.